### PR TITLE
Add basic support for some Red Hat distributions

### DIFF
--- a/lsb_release
+++ b/lsb_release
@@ -193,6 +193,20 @@ InitDistribInfo() {
 	    DISTRIB_ID=$MSG_DISTRIBUTOR
 	else
 	    case "$PRETTY_NAME" in
+		Fedora*)
+		    DISTRIB_ID="Fedora"
+		    ;;
+		CentOS*)
+		    DISTRIB_ID="CentOS"
+		    ;;
+		"Red Hat Enterprise Linux"*)
+		    DISTRIB_ID="RedHatEnterprise"
+		AlmaLinux*)
+		    DISTRIB_ID="AlmaLinux"
+		    ;;
+		Oracle*)
+		    DISTRIB_ID="OracleLinux"
+		    ;;
 		openSUSE*)
 		    DISTRIB_ID="openSUSE"
 		    ;;


### PR DESCRIPTION
redhat-lsb is not included in RHEL/CentOS 9, so in order to use this
as a substitute for lsb_release(1) formerly provided by redhat-lsb,
this adds some names to recognize and map to useful IDs.