### PR TITLE
Add a fallback "generic guess" for DISTRIB_ID using NAME 

### DIFF
--- a/lsb_release
+++ b/lsb_release
@@ -213,7 +213,7 @@ InitDistribInfo() {
 		openSUSE*)
 		    DISTRIB_ID="openSUSE"
 		    ;;
-		SUSE*)
+		SLE*|ALP*|SUSE*)
 		    DISTRIB_ID="SUSE"
 		    ;;
 		*)

--- a/lsb_release
+++ b/lsb_release
@@ -5,6 +5,7 @@
 # Copyright (C) 2000, 2002, 2004 Free Standards Group, Inc.
 # Originally by Dominique MASSONIE <mdomi@users.sourceforge.net>
 # Modified for SUSE Linux products by Thorsten Kukuk
+# Modified for Red Hat distributions by Neal Gompa
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -68,6 +69,7 @@ DisplayProgramVersion() {
     echo "Copyright (C) 2000, 2002, 2004 Free Standards Group, Inc."
     echo "Copyright (C) 2017 SUSE Linux GmbH"
     echo "Copyright (C) 2022 SUSE Software Solutions Germany GmbH"
+    echo "Copyright (C) 2021, 2023 Neal Gompa"
     echo
     echo "This is free software; see the source for copying conditions.  There is NO"
     echo "warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."

--- a/lsb_release
+++ b/lsb_release
@@ -194,7 +194,7 @@ InitDistribInfo() {
 	if [ -n "$MSG_DISTRIBUTOR" ]; then
 	    DISTRIB_ID=$MSG_DISTRIBUTOR
 	else
-	    case "$PRETTY_NAME" in
+	    case "$NAME" in
 		Fedora*)
 		    DISTRIB_ID="Fedora"
 		    ;;
@@ -217,7 +217,7 @@ InitDistribInfo() {
 		    DISTRIB_ID="SUSE"
 		    ;;
 		*)
-		    DISTRIB_ID=$MSG_NA
+		    DISTRIB_ID=$(echo $NAME | tr -d '[:blank:]')
 		    ;;
 	    esac
 	fi

--- a/lsb_release
+++ b/lsb_release
@@ -32,7 +32,7 @@
 ###############################################################################
 
 # This script version
-SCRIPTVERSION="3.1"
+SCRIPTVERSION="3.2"
 
 # Defines the data files
 INFO_LSB_FILE="/etc/lsb-release"              # where to get LSB version


### PR DESCRIPTION
Instead of using PRETTY_NAME, we can use NAME so that the identification is more consistent, and we can produce some kind of reasonable fallback.